### PR TITLE
Update footer links to policies

### DIFF
--- a/components/site/skin/palemoon/site-template.xhtml
+++ b/components/site/skin/palemoon/site-template.xhtml
@@ -61,8 +61,8 @@
           Any other content, brand names or logos are copyright or trademark to their respective owners.
         </span><br />
         <span style="color: rgb(102, 102, 102);">
-          Policies: <a href="//www.palemoon.org/cookies.shtml">Cookies</a> - <a href="//www.palemoon.org/usercontent.shtml">User Content</a>
-          - <a href="//www.palemoon.org/privacy.shtml">Privacy</a>.
+          Policies: <a href="//www.palemoon.org/policies/cookies.shtml">Cookies</a> - <a href="//www.palemoon.org/policies/usercontent.shtml">User Content</a>
+          - <a href="//www.palemoon.org/policies/privacy.shtml">Privacy</a>.
         </span></p>
         <p><span style="color: rgb(102, 102, 102);">
           The Pale Moon Add-ons Site is powered by <a href="https://github.com/Pale-Moon-Addons-Team/phoebus/" target="_blank">Project Phoebus</a> {$PHOEBUS_VERSION}.


### PR DESCRIPTION
They've been moved to `/policies/` on the main website.